### PR TITLE
add missing conda command in exercises/02_sequence_QC

### DIFF
--- a/exercises/02_sequence_QC.md
+++ b/exercises/02_sequence_QC.md
@@ -42,7 +42,7 @@ cd fastqc
 
 Before we run FastQC, we need to install the programs and activate the Conda environment that contains the program.
 ```bash
-create -y -n seqQC -c conda-forge -c bioconda -c defaults \
+conda create -y -n seqQC -c conda-forge -c bioconda -c defaults \
              cutadapt fastqc trimmomatic multiqc
 conda activate seqQC
 ```


### PR DESCRIPTION
I wasn't able to follow the tutorial until I placed the conda command in front of 'create'